### PR TITLE
feat(dunning)add custom button for auto email payment reminder

### DIFF
--- a/dunning/dunning/doctype/dunning/dunning.js
+++ b/dunning/dunning/doctype/dunning/dunning.js
@@ -15,6 +15,20 @@ frappe.ui.form.on('Dunning', {
 		});
 	},
 	refresh: function (frm) {
+    if(frm.doc.docstatus == 1){
+        frm.add_custom_button(__('Send Payment Reminder Email'), function () {
+            frappe.call({
+                method: "dunning.dunning.doctype.dunning.dunning.send_payment_reminder_email",
+                freeze: true,
+                freeze_message: __("Sending Payment Reminder Email..."),
+                args: {
+                    sales_invoice: frm.doc.sales_invoice,
+                    doc_name: frm.doc.name
+                },
+                callback: function (r) {}
+            })
+        })
+    }
 		frm.set_df_property("company", "read_only", frm.doc.__islocal ? 0 : 1);
 		frm.toggle_display("naming_series", false);
 		if (frm.is_new()) {

--- a/dunning/dunning/doctype/dunning/dunning.py
+++ b/dunning/dunning/doctype/dunning/dunning.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
+from frappe import _
 import json
 from six import string_types
 
@@ -28,3 +29,32 @@ def get_text_block(dunning_type, language, doc):
 			'top_text_block': frappe.render_template(text_block.top_text_block, doc),
 			'bottom_text_block': frappe.render_template(text_block.bottom_text_block, doc)
 		}
+	
+
+@frappe.whitelist()
+def send_payment_reminder_email(sales_invoice, doc_name):
+	si = frappe.db.get_value("Sales Invoice", sales_invoice, ["customer", "contact_person"], as_dict=1)
+	lang = frappe.db.get_value("Customer", si.customer, "language")
+	if lang == 'de':
+		template = 'zahlungserinnerung'
+		subject = "Zahlungserinnerung "+ sales_invoice
+	else:
+		template = 'payment_reminder'
+		subject = 'Payment Reminder ' + sales_invoice
+
+	sales_invoice_attachment = frappe.attach_print("Sales Invoice", sales_invoice, file_name=sales_invoice, lang=lang)
+	dunning_attachment = frappe.attach_print("Dunning", doc_name, file_name=doc_name, lang=lang)
+	recipients = frappe.db.get_value("Contact", si.contact_person, "email_id")
+	if recipients:
+		frappe.sendmail(recipients=recipients,
+							subject=subject,
+							template=template,
+							args=dict(
+								sales_invoice=sales_invoice,
+								doc_name=doc_name
+							),
+							attachments=[sales_invoice_attachment, dunning_attachment]
+							)
+		frappe.msgprint(_("Payment Reminder Email Sent to {0}").format(recipients))
+	else:
+		frappe.throw(_("No Email ID found in {0} check customer sales invoice contact person").format(sales_invoice))

--- a/dunning/templates/emails/payment_reminder.html
+++ b/dunning/templates/emails/payment_reminder.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>Dear Customer,Dear Sir or Madam,</p>
+    <p>Enclosed we send you our payment reminder {{ doc_name }} to the invoice {{sales_invoice}} with the request to take note. The copy of the invoice is attached to this e-mail.</p>
+    <p>Best regards from Newmatik</p>
+  </body>
+</html>

--- a/dunning/templates/emails/zahlungserinnerung.html
+++ b/dunning/templates/emails/zahlungserinnerung.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>Sehr geehrte Damen und Herren,</p>
+    <p>anbei senden wir Ihnen unsere Zahlungserinnerung {{ doc_name }} zur Rechnung {{sales_invoice}} mit der Bitte um Kenntnisnahme. Die Kopie der Rechnung hängt dieser E-Mail an.</p>
+    <p>Beste Grüße von Newmatik</p>
+  </body>
+</html>


### PR DESCRIPTION
ref : https://app.asana.com/0/home/1202488269211191/1205430390039131

Background of the Request:
The accounting team sends email reminders (Zahlungserinnerung) to defaulting customers, which should include the Dunning PF as well as the related Sales Invoice PF via ERPNext.

However, this is cumbersome for them because they still need to download the Sales Invoice PF and then attach it separately before sending an Email using the "New Email" function in ERPNext.

Thus, Ingrid is requesting for a new feature that allows them to attach the Sales Invoice PF automatically in the email.

Changes:
Instead of modal, added a new custom button to auto send out an email to the customers. 


SC:
<img width="1305" alt="image" src="https://github.com/elexess/erp-dunning/assets/85614308/343a59f3-d288-47ad-a859-2c3b31673b41">
