### PR TITLE
chore(requirements): comment out the frappe line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-frappe
+# frappe   # https://github.com/frappe/frappe is installed during bench-init


### PR DESCRIPTION
## Why

A bare `frappe` entry in `requirements.txt` makes a future `bench setup requirements` install the PyPI stub package `frappe` 0.0.1, which shadows the editable `apps/frappe` bench install. This bit the de-fork cutover at W.6.

## Fix

Comment out the `frappe` line to match `erpnext`'s `requirements.txt`. `frappe` is installed by `bench-init`, not from app requirements. Needed before the Phase D version hops.

[Claude Code]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency documentation with additional reference information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newmatik/erp-dunning/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->